### PR TITLE
Add support for ordinal suffix.

### DIFF
--- a/moment-tokens.js
+++ b/moment-tokens.js
@@ -60,6 +60,8 @@
                 return "H";
             case "e":
                 return "zz";
+            case "S":
+                return "o";
             default:
                 return item;
         }


### PR DESCRIPTION
I ran into a use case where the ordinal suffix token was not being replaced when converting from moment to php date format. I've added the missing token.
